### PR TITLE
Fix fetchProblemCatalog error handling

### DIFF
--- a/src/api/leetcode.test.ts
+++ b/src/api/leetcode.test.ts
@@ -60,7 +60,11 @@ describe('fetchProblemCatalog', () => {
       },
     ];
 
-    (fetch as any).mockResolvedValueOnce({ json: async () => mockData });
+    (fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockData,
+    });
 
     const result = await fetchProblemCatalog('https://example.com/data.json');
 
@@ -77,6 +81,14 @@ describe('fetchProblemCatalog', () => {
         createdAt: 1746308137,
       },
     ]);
+  });
+
+  it('throws when HTTP status is not ok', async () => {
+    (fetch as any).mockResolvedValueOnce({ ok: false, status: 404 });
+
+    await expect(fetchProblemCatalog('https://example.com/missing.json')).rejects.toThrow(
+      'HTTP 404',
+    );
   });
 });
 

--- a/src/api/leetcode.ts
+++ b/src/api/leetcode.ts
@@ -40,6 +40,9 @@ export function mapTagsToCategories(tags: string[]): Category[] {
 // Fetch full problem catalog from hosted JSON (URL configurable)
 export async function fetchProblemCatalog(url: string): Promise<Problem[]> {
   const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
   const data: RawProblemData[] = await res.json();
 
   return data.map((p) => ({


### PR DESCRIPTION
## Summary
- throw an error when problem catalog fetch fails
- test the failure path for `fetchProblemCatalog`

## Testing
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f60eb9d0883329bc6d8d3af6834a4