### PR TITLE
Implement solve history screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,24 @@
+import { useState } from 'react';
 import { useInitApp } from '@/hooks/useInitApp';
 import Dashboard from '@/components/Dashboard';
+import SolveHistory from '@/components/SolveHistory';
 import SignIn from '@/components/SignIn';
 
 function App() {
   const { loading, username } = useInitApp();
+  const [screen, setScreen] = useState<'dashboard' | 'history'>('dashboard');
 
   if (loading) {
     return <div className="min-h-screen flex items-center justify-center">Loading…</div>;
   }
 
-  return username ? <Dashboard /> : <SignIn />;
+  if (!username) return <SignIn />;
+
+  return screen === 'dashboard' ? (
+    <Dashboard onNavigate={setScreen} />
+  ) : (
+    <SolveHistory onNavigate={setScreen} />
+  );
 }
 
 export default App;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,19 +7,17 @@ import { ProfileManager } from '@/components/ProfileManager';
 import { getCategorySuggestions, getRandomSuggestions } from '@/domain/recommendations';
 import { CategoryRecommendation } from '@/types/recommendation';
 import { db } from '@/storage/db';
-import { Tooltip } from 'react-tooltip';
 import 'react-tooltip/dist/react-tooltip.css';
 
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { ProgressBar } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
-import { ThemeToggle } from '@/components/ThemeToggle';
-import { ModeBadge } from '@/components/ModeBadge';
 import { ExtensionWarning } from '@/components/ExtensionWarning';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { useTimeAgo } from '@/hooks/useTimeAgo';
 import ProblemCards from './ProblemCards';
 import type { Category } from '@/types/types';
+import { TopNav } from './TopNav';
 
 export const RANDOM_TAG: Category = 'Random';
 const initialSuggestions = {} as Record<Category, CategoryRecommendation>;
@@ -125,40 +123,7 @@ export default function Dashboard() {
   return (
     <div className="min-h-screen bg-background">
       {/* ───────── Nav Bar ───────── */}
-      <nav className="border-b bg-card">
-        <div className="max-w-6xl mx-auto flex h-16 items-center px-4 sm:px-6">
-          <div className="flex items-center gap-4">
-            <h1 className="text-lg font-semibold">LeetTracker</h1>
-            <ModeBadge />
-          </div>
-          <div className="ml-auto flex items-center gap-4">
-            {/* top‑level tabs (placeholder – navigation not wired yet) */}
-            <Tabs defaultValue="dashboard" className="mr-4 hidden sm:block">
-              <TabsList>
-                <TabsTrigger value="dashboard" disabled>
-                  Dashboard
-                </TabsTrigger>
-                <div id="solveHistoryTooltip">
-                  <TabsTrigger value="history" disabled>
-                    Solve History
-                  </TabsTrigger>
-                </div>
-                <Tooltip
-                  anchorId="solveHistoryTooltip"
-                  content="Work in progress"
-                  place="top"
-                  className="rounded-md bg-black text-white px-2 py-1 text-sm shadow-md"
-                />
-              </TabsList>
-            </Tabs>
-
-            <ThemeToggle />
-            <Button variant="ghost" onClick={handleSignOut}>
-              Sign Out
-            </Button>
-          </div>
-        </div>
-      </nav>
+      <TopNav active="dashboard" onSignOut={handleSignOut} />
       {profileManagerOpen && (
         <ProfileManager
           onDone={async () => {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -24,7 +24,11 @@ const initialSuggestions = {} as Record<Category, CategoryRecommendation>;
 
 /* ---------- Main Component ---------- */
 
-export default function Dashboard() {
+export default function Dashboard({
+  onNavigate,
+}: {
+  onNavigate?: (_screen: 'dashboard' | 'history') => void;
+}) {
   const { loading, username, progress, refresh, criticalError, extensionInstalled } = useInitApp();
   const [open, setOpen] = useState<Category | null>(null);
   const [suggestions, setSuggestions] =
@@ -123,7 +127,7 @@ export default function Dashboard() {
   return (
     <div className="min-h-screen bg-background">
       {/* ───────── Nav Bar ───────── */}
-      <TopNav active="dashboard" onSignOut={handleSignOut} />
+      <TopNav active="dashboard" onNavigate={onNavigate} onSignOut={handleSignOut} />
       {profileManagerOpen && (
         <ProfileManager
           onDone={async () => {

--- a/src/components/SolveHistory.tsx
+++ b/src/components/SolveHistory.tsx
@@ -10,6 +10,7 @@ import { Select } from '@/components/ui/select';
 import { TopNav } from './TopNav';
 import { useToast } from './ui/toast';
 import type { Solve } from '@/types/types';
+import { db } from '@/storage/db';
 
 // Temporary mock data
 const mockSolves: Solve[] = [
@@ -32,7 +33,11 @@ const mockSolves: Solve[] = [
   },
 ];
 
-export default function SolveHistory() {
+export default function SolveHistory({
+  onNavigate,
+}: {
+  onNavigate?: (_screen: 'dashboard' | 'history') => void;
+}) {
   const [selectedSolve, setSelectedSolve] = useState<Solve | null>(mockSolves[0]);
   const [showSidebar, setShowSidebar] = useState(true);
   const [expandedCode, setExpandedCode] = useState(false);
@@ -42,6 +47,17 @@ export default function SolveHistory() {
     selectedSolve?.solveDetails || { solveTime: '', usedHints: 'none', userNotes: '' },
   );
   const toast = useToast();
+
+  const handleSignOut = async () => {
+    if (!window.confirm('Are you sure you want to sign out? Your local progress will be cleared.'))
+      return;
+    await db.setActiveGoalProfile('default');
+    await db.clearGoalProfiles();
+    await db.setUsername('');
+    await db.clearSolves();
+    await db.setExtensionLastTimestamp(0);
+    window.location.reload();
+  };
 
   const formatTimestamp = (ts: number) => {
     const d = new Date(ts * 1000);
@@ -54,7 +70,7 @@ export default function SolveHistory() {
 
   return (
     <div className="min-h-screen bg-background">
-      <TopNav active="history" onSignOut={() => {}} />
+      <TopNav active="history" onNavigate={onNavigate} onSignOut={handleSignOut} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
         <div className="flex gap-6" style={{ height: 'calc(100vh - 8rem)' }}>
           {/* Sidebar */}

--- a/src/components/SolveHistory.tsx
+++ b/src/components/SolveHistory.tsx
@@ -1,0 +1,307 @@
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight, Edit, Save, X, Eye, EyeOff } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { Select } from '@/components/ui/select';
+import { TopNav } from './TopNav';
+import { useToast } from './ui/toast';
+import type { Solve } from '@/types/types';
+
+// Temporary mock data
+const mockSolves: Solve[] = [
+  {
+    slug: 'two-sum',
+    title: 'Two Sum',
+    timestamp: Math.floor(Date.now() / 1000) - 86400,
+    status: 'Accepted',
+    lang: 'ts',
+    problemDescription:
+      'Given an array of integers nums and an integer target, return indices of the two numbers such that they add up to target.',
+    code: 'function twoSum() {}',
+    difficulty: undefined,
+    tags: ['Array'],
+    solveDetails: {
+      solveTime: '15 minutes',
+      usedHints: 'none',
+      userNotes: 'Classic problem.',
+    },
+  },
+];
+
+export default function SolveHistory() {
+  const [selectedSolve, setSelectedSolve] = useState<Solve | null>(mockSolves[0]);
+  const [showSidebar, setShowSidebar] = useState(true);
+  const [expandedCode, setExpandedCode] = useState(false);
+  const [expandedDescription, setExpandedDescription] = useState(false);
+  const [editingSolveDetails, setEditingSolveDetails] = useState(false);
+  const [solveDetailsForm, setSolveDetailsForm] = useState(
+    selectedSolve?.solveDetails || { solveTime: '', usedHints: 'none', userNotes: '' },
+  );
+  const toast = useToast();
+
+  const formatTimestamp = (ts: number) => {
+    const d = new Date(ts * 1000);
+    return (
+      d.toLocaleDateString() +
+      ' ' +
+      d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <TopNav active="history" onSignOut={() => {}} />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        <div className="flex gap-6" style={{ height: 'calc(100vh - 8rem)' }}>
+          {/* Sidebar */}
+          <div
+            className={`transition-all duration-300 ${showSidebar ? 'w-64' : 'w-0'} overflow-hidden`}
+          >
+            <Card className="h-full">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-lg">Solve History</CardTitle>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowSidebar(false)}
+                    className="p-1"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent className="p-0">
+                <ScrollArea className="h-full">
+                  <div className="space-y-2 p-4 pt-0">
+                    {mockSolves.map((solve) => (
+                      <div
+                        key={solve.timestamp}
+                        onClick={() => {
+                          setSelectedSolve(solve);
+                          setSolveDetailsForm(
+                            solve.solveDetails || {
+                              solveTime: '',
+                              usedHints: 'none',
+                              userNotes: '',
+                            },
+                          );
+                        }}
+                        className={`p-3 rounded-lg border cursor-pointer transition-colors hover:bg-muted ${
+                          selectedSolve?.timestamp === solve.timestamp ? 'bg-muted' : ''
+                        }`}
+                      >
+                        <h4 className="font-medium text-sm truncate">{solve.title}</h4>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {formatTimestamp(solve.timestamp)}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </CardContent>
+            </Card>
+          </div>
+
+          {!showSidebar && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowSidebar(true)}
+              className="fixed left-4 top-32 z-10"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          )}
+
+          {/* Main content */}
+          <div className="flex-1 min-w-0">
+            {selectedSolve ? (
+              <Card className="h-full">
+                <CardHeader>
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <CardTitle className="text-xl">{selectedSolve.title}</CardTitle>
+                      <div className="flex items-center gap-2 mt-2 text-sm text-muted-foreground">
+                        {formatTimestamp(selectedSolve.timestamp)}
+                      </div>
+                    </div>
+                    {!showSidebar && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowSidebar(true)}
+                        className="gap-2"
+                      >
+                        <Eye className="h-4 w-4" /> Show List
+                      </Button>
+                    )}
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <ScrollArea className="h-full">
+                    <div className="space-y-6">
+                      {/* Problem Description */}
+                      <div>
+                        <div className="flex items-center justify-between mb-2">
+                          <h3 className="font-semibold">Problem Description</h3>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setExpandedDescription((v) => !v)}
+                            className="gap-2"
+                          >
+                            {expandedDescription ? (
+                              <EyeOff className="h-4 w-4" />
+                            ) : (
+                              <Eye className="h-4 w-4" />
+                            )}
+                            {expandedDescription ? 'Collapse' : 'Expand'}
+                          </Button>
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {expandedDescription
+                            ? selectedSolve.problemDescription
+                            : (selectedSolve.problemDescription || '').slice(0, 200)}
+                        </p>
+                      </div>
+
+                      <Separator />
+
+                      {/* Submission Code */}
+                      <div>
+                        <div className="flex items-center justify-between mb-2">
+                          <h3 className="font-semibold">Submission Code</h3>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setExpandedCode((v) => !v)}
+                            className="gap-2"
+                          >
+                            {expandedCode ? (
+                              <EyeOff className="h-4 w-4" />
+                            ) : (
+                              <Eye className="h-4 w-4" />
+                            )}
+                            {expandedCode ? 'Collapse' : 'Expand'}
+                          </Button>
+                        </div>
+                        <div className="bg-muted rounded-lg p-4">
+                          <pre className="text-sm overflow-x-auto">
+                            <code>
+                              {expandedCode
+                                ? selectedSolve.code
+                                : (selectedSolve.code || '').split('\n').slice(0, 20).join('\n')}
+                            </code>
+                          </pre>
+                        </div>
+                      </div>
+
+                      <Separator />
+
+                      {/* Solve Details */}
+                      <div>
+                        <div className="flex items-center justify-between mb-4">
+                          <h3 className="font-semibold">Solve Details</h3>
+                          {!editingSolveDetails ? (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setEditingSolveDetails(true)}
+                              className="gap-2"
+                            >
+                              <Edit className="h-4 w-4" /> Edit
+                            </Button>
+                          ) : (
+                            <div className="flex gap-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setEditingSolveDetails(false)}
+                                className="gap-2"
+                              >
+                                <X className="h-4 w-4" /> Cancel
+                              </Button>
+                              <Button
+                                size="sm"
+                                onClick={() => {
+                                  setEditingSolveDetails(false);
+                                  toast('Saved');
+                                }}
+                                className="gap-2"
+                              >
+                                <Save className="h-4 w-4" /> Save
+                              </Button>
+                            </div>
+                          )}
+                        </div>
+                        {editingSolveDetails ? (
+                          <div className="grid gap-4">
+                            <div>
+                              <label className="text-sm font-medium block mb-1">Solve Time</label>
+                              <Input
+                                value={solveDetailsForm.solveTime}
+                                onChange={(e) =>
+                                  setSolveDetailsForm((p) => ({ ...p, solveTime: e.target.value }))
+                                }
+                              />
+                            </div>
+                            <div>
+                              <label className="text-sm font-medium block mb-1">Used Hints</label>
+                              <Select
+                                value={solveDetailsForm.usedHints}
+                                onChange={(e) =>
+                                  setSolveDetailsForm((p) => ({
+                                    ...p,
+                                    usedHints: e.target.value as any,
+                                  }))
+                                }
+                              >
+                                <option value="none">None</option>
+                                <option value="leetcode_hint">LeetCode Hint</option>
+                                <option value="solution_peek">Solution Peek</option>
+                                <option value="gpt_help">GPT Help</option>
+                              </Select>
+                            </div>
+                            <div>
+                              <label className="text-sm font-medium block mb-1">Notes</label>
+                              <Textarea
+                                rows={3}
+                                value={solveDetailsForm.userNotes}
+                                onChange={(e) =>
+                                  setSolveDetailsForm((p) => ({ ...p, userNotes: e.target.value }))
+                                }
+                              />
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="grid gap-3 text-sm text-muted-foreground">
+                            <div>Time: {solveDetailsForm.solveTime || 'Not specified'}</div>
+                            <div>Hints: {solveDetailsForm.usedHints}</div>
+                            {solveDetailsForm.userNotes && (
+                              <p className="mt-1">{solveDetailsForm.userNotes}</p>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </ScrollArea>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card className="h-full flex items-center justify-center">
+                <CardContent>
+                  <p className="text-center text-muted-foreground">Select a solve from the list.</p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,0 +1,48 @@
+import { ModeBadge } from './ModeBadge';
+import { ThemeToggle } from './ThemeToggle';
+import { Tabs, TabsList, TabsTrigger } from './ui/tabs';
+import { Button } from './ui/button';
+import { Tooltip } from 'react-tooltip';
+import 'react-tooltip/dist/react-tooltip.css';
+
+interface TopNavProps {
+  active: 'dashboard' | 'history';
+  onSignOut: () => void;
+}
+
+export function TopNav({ active, onSignOut }: TopNavProps) {
+  return (
+    <nav className="border-b bg-card">
+      <div className="max-w-6xl mx-auto flex h-16 items-center px-4 sm:px-6">
+        <div className="flex items-center gap-4">
+          <h1 className="text-lg font-semibold">LeetTracker</h1>
+          <ModeBadge />
+        </div>
+        <div className="ml-auto flex items-center gap-4">
+          <Tabs defaultValue={active} className="mr-4 hidden sm:block">
+            <TabsList>
+              <TabsTrigger value="dashboard" disabled>
+                Dashboard
+              </TabsTrigger>
+              <div id="solveHistoryTooltip">
+                <TabsTrigger value="history" disabled>
+                  Solve History
+                </TabsTrigger>
+              </div>
+              <Tooltip
+                anchorId="solveHistoryTooltip"
+                content="Work in progress"
+                place="top"
+                className="rounded-md bg-black text-white px-2 py-1 text-sm shadow-md"
+              />
+            </TabsList>
+          </Tabs>
+          <ThemeToggle />
+          <Button variant="ghost" onClick={onSignOut}>
+            Sign Out
+          </Button>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -2,15 +2,14 @@ import { ModeBadge } from './ModeBadge';
 import { ThemeToggle } from './ThemeToggle';
 import { Tabs, TabsList, TabsTrigger } from './ui/tabs';
 import { Button } from './ui/button';
-import { Tooltip } from 'react-tooltip';
-import 'react-tooltip/dist/react-tooltip.css';
 
 interface TopNavProps {
   active: 'dashboard' | 'history';
+  onNavigate?: (_screen: 'dashboard' | 'history') => void;
   onSignOut: () => void;
 }
 
-export function TopNav({ active, onSignOut }: TopNavProps) {
+export function TopNav({ active, onNavigate, onSignOut }: TopNavProps) {
   return (
     <nav className="border-b bg-card">
       <div className="max-w-6xl mx-auto flex h-16 items-center px-4 sm:px-6">
@@ -19,22 +18,14 @@ export function TopNav({ active, onSignOut }: TopNavProps) {
           <ModeBadge />
         </div>
         <div className="ml-auto flex items-center gap-4">
-          <Tabs defaultValue={active} className="mr-4 hidden sm:block">
+          <Tabs key={active} defaultValue={active} className="mr-4 hidden sm:block">
             <TabsList>
-              <TabsTrigger value="dashboard" disabled>
+              <TabsTrigger value="dashboard" onClick={() => onNavigate?.('dashboard')}>
                 Dashboard
               </TabsTrigger>
-              <div id="solveHistoryTooltip">
-                <TabsTrigger value="history" disabled>
-                  Solve History
-                </TabsTrigger>
-              </div>
-              <Tooltip
-                anchorId="solveHistoryTooltip"
-                content="Work in progress"
-                place="top"
-                className="rounded-md bg-black text-white px-2 py-1 text-sm shadow-md"
-              />
+              <TabsTrigger value="history" onClick={() => onNavigate?.('history')}>
+                Solve History
+              </TabsTrigger>
             </TabsList>
           </Tabs>
           <ThemeToggle />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,14 @@
+import type { InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={clsx(
+        'border border-input bg-background rounded-md px-2 py-1 text-sm w-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,6 @@
+import type { HTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function ScrollArea({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={clsx('overflow-y-auto', className)} {...props} />;
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,13 @@
+import type { SelectHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function Select({ className, children, ...props }: SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select
+      className={clsx('border border-input rounded-md px-2 py-1 text-sm', className)}
+      {...props}
+    >
+      {children}
+    </select>
+  );
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,6 @@
+import type { HTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function Separator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={clsx('border-b border-border my-4', className)} {...props} />;
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,14 @@
+import type { TextareaHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function Textarea({ className, ...props }: TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      className={clsx(
+        'border border-input bg-background rounded-md px-2 py-1 text-sm w-full',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -103,10 +103,37 @@ export interface Solve {
   status: string;
   lang: string; // e.g. "python3", "cpp", etc.
   code?: string; // full source code
+  /** Optional problem description at time of solve */
+  problemDescription?: string;
   difficulty?: Difficulty; // ← optional at first, inferred from Problem DB
   tags?: Category[]; // ← optional at first, inferred from Problem DB
   timeUsed?: number; // Optional: user input later
   hintUsed?: boolean; // Optional: if user flags this
+  /** Additional details recorded by the user */
+  solveDetails?: {
+    solveTime?: string;
+    usedHints?: 'none' | 'leetcode_hint' | 'solution_peek' | 'gpt_help';
+    userNotes?: string;
+  };
+  /** Structured feedback from manual entry or LLM */
+  feedback?: {
+    performance: {
+      time_to_solve: number;
+      time_complexity: string;
+      space_complexity: string;
+      comments: string;
+    };
+    code_quality: {
+      readability: number;
+      correctness: number;
+      maintainability: number;
+      comments: string;
+    };
+    summary: {
+      final_score: number;
+      comments: string;
+    };
+  };
   qualityScore?: number; // Optional: manual or GPT
 }
 


### PR DESCRIPTION
## Summary
- add new `TopNav` component shared between screens
- introduce a basic Solve History page with editable solve details
- extend `Solve` type with optional details and feedback fields
- expose simple UI primitives for inputs and scrolling
- refactor Dashboard to use `TopNav`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686080dbc9f48332af2319ef7cfda43e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "Solve History" page for browsing and editing details of past solved problems, including problem descriptions, code, and user notes.
  * Added a unified top navigation bar with theme toggle and sign-out options.
  * Added new UI components for inputs, selects, textareas, scrollable areas, and separators.

* **Improvements**
  * Enhanced the data model for solved problems to support detailed solve information and structured feedback.
  * Enabled navigation between Dashboard and Solve History pages within the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->